### PR TITLE
Prevent concurrent modification of sessions hash

### DIFF
--- a/test/configuration/connections_test.rb
+++ b/test/configuration/connections_test.rb
@@ -233,6 +233,17 @@ class ConfigurationConnectionsTest < Test::Unit::TestCase
     assert_equal %w(cap1 cap2 cap3), @config.sessions.keys.sort.map { |s| s.host }
   end
 
+  def test_execute_on_servers_with_many_servers
+    assert @config.sessions.empty?
+    @config.current_task = mock_task
+    server_names = 128.times.map {|i| "cap#{i}" }
+    Capistrano::SSH.stubs(:connect).returns(:success)
+    @config.establish_connections_to(server_names.map { |sn| server(sn) })
+    assert_equal server_names.length, @config.sessions.length
+    assert_equal server_names.sort, @config.sessions.keys.map(&:host).sort
+    assert !@config.sessions.values.any?(&:nil?)
+  end
+
   def test_execute_on_servers_should_yield_server_list_to_block
     assert @config.sessions.empty?
     @config.current_task = mock_task


### PR DESCRIPTION
This should prevent: NoMethodError: undefined method `xserver' for nil:NilClass that we sometimes see when we deploy.

On JRuby the tests still don't pass all the time, but that was true before this patch.
