### PR TITLE
feat: Allow setting CAP_USER env-var to override USER

### DIFF
--- a/lib/capistrano/server_definition.rb
+++ b/lib/capistrano/server_definition.rb
@@ -9,7 +9,7 @@ module Capistrano
 
     # The default user name to use when a user name is not explicitly provided
     def self.default_user
-      ENV['USER'] || ENV['USERNAME'] || "not-specified"
+      ENV['CAP_USER'] || ENV['USER'] || ENV['USERNAME'] || "not-specified"
     end
 
     def initialize(string, options={})


### PR DESCRIPTION
My local Mac user is `rachel`, but my upstream VPN user is `rforshee`. I'd like to be able to set this once in my local environment config and forget about it, rather than prefix all of my `bundle exec cap` commands with `USER=rforshee`, similar to the `CHEF_USER` functionality that we have in `swiftype/infra`.